### PR TITLE
Error running SysNative on Windows 10 x64

### DIFF
--- a/Helpers/OptimizationOptions.cs
+++ b/Helpers/OptimizationOptions.cs
@@ -375,7 +375,7 @@ internal partial class OptimizationOptions
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = Environment.Is64BitOperatingSystem
+                    FileName = Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess
                         ? Path.Combine(Environment.GetEnvironmentVariable("windir"), @"SysNative\cmd.exe")
                         : Path.Combine(Environment.GetEnvironmentVariable("windir"), @"System32\cmd.exe"),
                     Arguments = $"/C {command}",


### PR DESCRIPTION
When running a command on a 64-bit Windows 10 host with an application compiled for x64, the following error was obtained: System.ComponentModel.Win32Exception: 'An error occurred trying to start process 'C:\Windows\SysNative\cmd.exe' with working directory 'C:\Windows\system32'. El sistema no puede encontrar el archivo especificado.'
This error occurs because “SysNative” is a virtual alias that is only available for 32-bit processes.

Explanation
In 64-bit Windows, there are two folders for system binaries:
C:\Windows\System32: Contains 64-bit binaries.
C:\Windows\SysWOW64: Contains 32-bit binaries, used by 32-bit applications on a 64-bit system.

When a 32-bit application attempts to access C:\Windows\System32, the system automatically redirects the request to C:\Windows\SysWOW64. To bypass this redirection and allow a 32-bit application to access 64-bit binaries within System32, Windows provides the special alias SysNative.

Cause of the problem
The current code only checks if the operating system is 64-bit and, based on that, assigns “SysNative”. However, this alias is not available for 64-bit applications, so the execution fails.

Solution
In addition to checking whether the system is 64-bit, it is also necessary to check whether the running application is 32-bit or 64-bit. If the application is 64-bit, you should access System32 directly instead of using SysNative.